### PR TITLE
`amd-mainline` is no longer the default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ etc.
 
 ## Contributing
 
-The default branch is `amd-mainline` but the only branch that should target that branch in a pull requests is the `amd-staging` branch.
-
-> _**All pull-requests should target the `amd-staging` branch**_
+All pull-requests should target the `amd-staging` branch.
 
 ### Creating a feature branch
 


### PR DESCRIPTION
I noticed that the "CONTRIBUTING" section was still referencing `amd-mainline` as the default branch.